### PR TITLE
예외 로그 개선 등

### DIFF
--- a/src/main/java/com/jlog/config/SerializationConfig.java
+++ b/src/main/java/com/jlog/config/SerializationConfig.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 @Configuration
 public class SerializationConfig {
 
-    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss+09:00";
 
     @Bean
     public Jackson2ObjectMapperBuilderCustomizer jackson2ObjectMapperBuilderCustomizer() {

--- a/src/main/java/com/jlog/domain/log/Log.java
+++ b/src/main/java/com/jlog/domain/log/Log.java
@@ -28,12 +28,13 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-@EqualsAndHashCode(of = "id", callSuper = false)
+@EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
 @ToString
 public class Log extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     @ManyToOne(optional = false)
@@ -65,5 +66,13 @@ public class Log extends BaseEntity {
 
     public void updateMemo(String memo) {
         this.memo = memo;
+    }
+
+    public String getRoomCode() {
+        return room.getCode();
+    }
+
+    public String getMemberName() {
+        return member.getName();
     }
 }

--- a/src/main/java/com/jlog/domain/log/LogController.java
+++ b/src/main/java/com/jlog/domain/log/LogController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
+@SuppressWarnings("removal")
 @RestController
 @RequestMapping(consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
@@ -62,7 +63,7 @@ public class LogController {
             @RequestBody LogRequestV1 request
     ) {
         request = LogRequestV1.of(roomCode, username, request.expense(), request.memo());
-        Log log = logService.create(request);
+        var log = logService.create(request);
         return LogResponseV1.from(log);
     }
 
@@ -84,8 +85,8 @@ public class LogController {
             @RequestParam("username") String username,
             @RequestBody LogRequestV1 request
     ) {
-        request = new LogRequestV1(id, roomCode, username, request.expense(), request.memo());
-        Log log = logService.update(request);
+        request = LogRequestV1.of(id, roomCode, username, request.expense(), request.memo());
+        var log = logService.update(request);
         return LogResponseV1.from(log);
     }
 

--- a/src/main/java/com/jlog/domain/log/LogRequest.java
+++ b/src/main/java/com/jlog/domain/log/LogRequest.java
@@ -7,6 +7,8 @@ import jakarta.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated(forRemoval = true)
 public record LogRequest(
 
         @JsonProperty("log_id")

--- a/src/main/java/com/jlog/domain/log/LogRequestV1.java
+++ b/src/main/java/com/jlog/domain/log/LogRequestV1.java
@@ -24,15 +24,15 @@ public record LogRequestV1(
 
 ) implements LogDto {
 
-    public static LogRequestV1 of(String roomCode, String username) {
-        return of(null, roomCode, username);
+    public static LogRequestV1 of(Long id, String roomCode, String username, Long expense, String memo) {
+        return new LogRequestV1(id, roomCode, username, expense, memo);
     }
 
     public static LogRequestV1 of(Long id, String roomCode, String username) {
-        return new LogRequestV1(id, roomCode, username, null, null);
+        return of(id, roomCode, username, null, null);
     }
 
     public static LogRequestV1 of(String roomCode, String username, Long expense, String memo) {
-        return new LogRequestV1(null, roomCode, username, expense, memo);
+        return of(null, roomCode, username, expense, memo);
     }
 }

--- a/src/main/java/com/jlog/domain/log/LogResponse.java
+++ b/src/main/java/com/jlog/domain/log/LogResponse.java
@@ -5,6 +5,8 @@ import java.time.LocalDateTime;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated(forRemoval = true)
 public record LogResponse(
 
         @JsonProperty("log_id")
@@ -31,8 +33,8 @@ public record LogResponse(
         public static LogResponse from(Log log) {
                 return new LogResponse(
                         log.getId(),
-                        log.getRoom().getCode(),
-                        log.getMember().getName(),
+                        log.getRoomCode(),
+                        log.getMemberName(),
                         log.getExpense(),
                         log.getMemo(),
                         log.getCreatedAt(),

--- a/src/main/java/com/jlog/domain/log/LogResponseV1.java
+++ b/src/main/java/com/jlog/domain/log/LogResponseV1.java
@@ -14,8 +14,8 @@ public record LogResponseV1(
     public static LogResponseV1 from(Log log) {
         return new LogResponseV1(
                 log.getId(),
-                log.getRoom().getCode(),
-                log.getMember().getName(),
+                log.getRoomCode(),
+                log.getMemberName(),
                 log.getExpense(),
                 log.getMemo(),
                 log.getCreatedAt(),

--- a/src/main/java/com/jlog/domain/log/LogService.java
+++ b/src/main/java/com/jlog/domain/log/LogService.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.jlog.domain.member.Member;
-import com.jlog.domain.room.Room;
 import com.jlog.domain.room.RoomRepository;
 import com.jlog.exception.JLogException;
 
@@ -35,50 +34,49 @@ public class LogService {
 
     @Transactional
     public Log create(LogDto request) {
-        Room room = roomRepository.fetchByCode(request.roomCode());
-        Member member = room.getMemberByName(request.username());
+        var room = roomRepository.fetchByCode(request.roomCode());
+        var member = room.getMemberByName(request.username());
         Objects.requireNonNull(member);
-        Log saved = logRepository.save(Log.builder()
+        var log = Log.builder()
                 .room(room)
                 .member(member)
                 .expense(request.expense())
                 .memo(request.memo())
-                .build());
+                .build();
+        var saved = logRepository.save(log);
         member.addExpense(saved.getExpense());
         return saved;
     }
 
+    @SuppressWarnings({"removal", "DeprecatedIsStillUsed"})
+    @Deprecated(forRemoval = true)
     @Transactional(readOnly = true)
     public LogsWithOutpayResponse findAll(String roomCode, String username) {
-        Room room = roomRepository.fetchByCode(roomCode);
-        Member member = room.getMemberByName(username);
+        var room = roomRepository.fetchByCode(roomCode);
+        var member = room.getMemberByName(username);
         Objects.requireNonNull(member);
-        List<LogResponse> logs = findAllLogsByRoomOrderByCreatedDateDesc(room);
-        return LogsWithOutpayResponse.of(room, logs);
-    }
-
-    private List<LogResponse> findAllLogsByRoomOrderByCreatedDateDesc(Room room) {
-        return logRepository.findAllByRoom(room)
+        var logs = logRepository.findAllByRoom(room)
                 .stream()
                 .map(LogResponse::from)
                 .sorted(comparing(LogResponse::createdAt, reverseOrder()))
                 .toList();
+        return LogsWithOutpayResponse.of(room, logs);
     }
 
     @Transactional(readOnly = true)
     public List<Log> findLogsByRoomAndLastId(LogDto request) {
-        Room room = roomRepository.fetchByCode(request.roomCode());
-        Member member = room.getMemberByName(request.username());
+        var room = roomRepository.fetchByCode(request.roomCode());
+        var member = room.getMemberByName(request.username());
         Objects.requireNonNull(member);
-        PageRequest pageRequest = PageRequest.of(0, DEFAULT_CONTENT_SIZE, DEFAULT_SORT);
+        var pageRequest = PageRequest.of(0, DEFAULT_CONTENT_SIZE, DEFAULT_SORT);
         return logRepository.findLogsByRoomAndLastId(room, request.id(), pageRequest);
     }
 
     @Transactional
     public Log update(LogDto request) {
-        Room room = roomRepository.fetchByCode(request.roomCode());
-        Member member = room.getMemberByName(request.username());
-        Log log = logRepository.fetchById(request.id());
+        var room = roomRepository.fetchByCode(request.roomCode());
+        var member = room.getMemberByName(request.username());
+        var log = logRepository.fetchById(request.id());
         validateLogOwner(log, member);
         member.addExpense(request.expense() - log.getExpense());
         log.updateExpense(request.expense());
@@ -88,9 +86,9 @@ public class LogService {
 
     @Transactional
     public void delete(LogDto request) {
-        Room room = roomRepository.fetchByCode(request.roomCode());
-        Member member = room.getMemberByName(request.username());
-        Log log = logRepository.fetchById(request.id());
+        var room = roomRepository.fetchByCode(request.roomCode());
+        var member = room.getMemberByName(request.username());
+        var log = logRepository.fetchById(request.id());
         validateLogOwner(log, member);
         member.subtractExpense(log.getExpense());
         logRepository.delete(log);

--- a/src/main/java/com/jlog/domain/log/LogsWithOutpayResponse.java
+++ b/src/main/java/com/jlog/domain/log/LogsWithOutpayResponse.java
@@ -5,6 +5,8 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jlog.domain.room.Room;
 
+@SuppressWarnings({"removal", "DeprecatedIsStillUsed"})
+@Deprecated(forRemoval = true)
 public record LogsWithOutpayResponse(
         @JsonProperty("balance") OutpayResponse outpayResponse,
         List<LogResponse> logs

--- a/src/main/java/com/jlog/domain/member/Member.java
+++ b/src/main/java/com/jlog/domain/member/Member.java
@@ -21,12 +21,13 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-@EqualsAndHashCode(of = "id", callSuper = false)
+@EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
 @ToString
 public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     @Column(name = "name", length = 16, nullable = false)

--- a/src/main/java/com/jlog/domain/member/Members.java
+++ b/src/main/java/com/jlog/domain/member/Members.java
@@ -9,29 +9,30 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToOne;
 
-import com.jlog.domain.log.Log;
 import com.jlog.exception.JLogErrorCode;
 import com.jlog.exception.JLogException;
 
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @ToString
 public class Members {
 
     @OneToOne(optional = false)
     @AttributeOverride(name = "id", column = @Column(name = "member1_id"))
+    @EqualsAndHashCode.Include
     private Member member1;
 
     @OneToOne
     @AttributeOverride(name = "id", column = @Column(name = "member2_id"))
+    @EqualsAndHashCode.Include
     private Member member2;
 
     public Members(Member member) {
@@ -63,14 +64,6 @@ public class Members {
 
     public boolean existsByName(String name) {
         return stream().anyMatch(m -> m.matchName(name));
-    }
-
-    public void addLog(Log log) {
-        Member member = stream()
-                .filter(m -> Objects.equals(m, log.getMember()))
-                .findFirst()
-                .orElseThrow(IllegalArgumentException::new);
-        member.addExpense(log.getExpense());
     }
 
     public String outpayer() {

--- a/src/main/java/com/jlog/domain/room/Room.java
+++ b/src/main/java/com/jlog/domain/room/Room.java
@@ -17,19 +17,18 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-@EqualsAndHashCode(of = "id", callSuper = false)
+@EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
 @ToString
-@Slf4j
 public class Room extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     @Column(length = 8, nullable = false, unique = true)

--- a/src/main/java/com/jlog/domain/room/RoomController.java
+++ b/src/main/java/com/jlog/domain/room/RoomController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
+@SuppressWarnings("removal")
 @RestController
 @RequestMapping(consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
@@ -27,7 +28,7 @@ public class RoomController {
     @PostMapping(path = "/api/room")
     @ResponseStatus(HttpStatus.CREATED)
     public RoomCreateResponse create(@RequestBody @Valid RoomCreateRequest request) {
-        Room room = roomService.create(request);
+        var room = roomService.create(request);
         return new RoomCreateResponse(room.getCode());
     }
 
@@ -40,7 +41,7 @@ public class RoomController {
     @PostMapping(path = "api/v1/rooms")
     @ResponseStatus(HttpStatus.CREATED)
     public RoomResponse createV1(@RequestBody @Valid RoomRequestV1 request) {
-        Room room = roomService.create(request);
+        var room = roomService.create(request);
         return RoomResponse.from(room);
     }
 
@@ -50,7 +51,7 @@ public class RoomController {
             @RequestBody @Valid RoomRequestV1 request
     ) {
         request = new RoomRequestV1(roomCode, request.username());
-        Room room = roomService.join(request);
+        var room = roomService.join(request);
         return RoomResponse.from(room);
     }
 
@@ -60,7 +61,7 @@ public class RoomController {
             @RequestParam("username") String username
     ) {
         var request = new RoomRequestV1(roomCode, username);
-        Room room = roomService.get(request);
+        var room = roomService.get(request);
         return RoomResponse.from(room);
     }
 }

--- a/src/main/java/com/jlog/domain/room/RoomCreateRequest.java
+++ b/src/main/java/com/jlog/domain/room/RoomCreateRequest.java
@@ -3,6 +3,8 @@ package com.jlog.domain.room;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated(forRemoval = true)
 public record RoomCreateRequest(
         @NotBlank
         @Size(min = 2, max = 16)

--- a/src/main/java/com/jlog/domain/room/RoomCreateResponse.java
+++ b/src/main/java/com/jlog/domain/room/RoomCreateResponse.java
@@ -2,8 +2,7 @@ package com.jlog.domain.room;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record RoomCreateResponse(
-        @JsonProperty("room_code")
-        String code
-) {
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated(forRemoval = true)
+public record RoomCreateResponse(@JsonProperty("room_code") String code) {
 }

--- a/src/main/java/com/jlog/domain/room/RoomJoinRequest.java
+++ b/src/main/java/com/jlog/domain/room/RoomJoinRequest.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated(forRemoval = true)
 public record RoomJoinRequest(
 
         @JsonProperty("room_code")

--- a/src/main/java/com/jlog/exception/JLogException.java
+++ b/src/main/java/com/jlog/exception/JLogException.java
@@ -6,11 +6,6 @@ public class JLogException extends RuntimeException {
 
     private final JLogErrorCode errorCode;
 
-    public JLogException(String message) {
-        super(message);
-        errorCode = JLogErrorCode.SERVER_ERROR;
-    }
-
     public JLogException(JLogErrorCode errorCode) {
         super(errorCode.message());
         this.errorCode = errorCode;
@@ -18,9 +13,5 @@ public class JLogException extends RuntimeException {
 
     public HttpStatusCode httpStatus() {
         return errorCode.httpStatus();
-    }
-
-    public JLogErrorCode errorCode() {
-        return errorCode;
     }
 }

--- a/src/main/java/com/jlog/exception/JLogExceptionHandler.java
+++ b/src/main/java/com/jlog/exception/JLogExceptionHandler.java
@@ -24,7 +24,7 @@ public class JLogExceptionHandler extends ResponseEntityExceptionHandler {
             log.warn(message);
         }
         if (status.is5xxServerError()) {
-            log.error(message, exception);
+            log.error(exception.getMessage(), exception);
         }
         return ResponseEntity.status(status).body(message);
     }
@@ -32,12 +32,12 @@ public class JLogExceptionHandler extends ResponseEntityExceptionHandler {
     @Override
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<Object> handleExceptionInternal(
-            @NonNull Exception ex,
+            @NonNull Exception exception,
             @Nullable Object body,
             @NonNull HttpHeaders headers,
             @NonNull HttpStatusCode statusCode,
             @NonNull WebRequest request) {
-        log.error(ex.getMessage(), ex);
-        return super.handleExceptionInternal(ex, body, headers, statusCode, request);
+        log.error(exception.getMessage(), exception);
+        return super.handleExceptionInternal(exception, body, headers, statusCode, request);
     }
 }

--- a/src/main/java/com/jlog/logging/HttpLogFilter.java
+++ b/src/main/java/com/jlog/logging/HttpLogFilter.java
@@ -1,4 +1,4 @@
-package com.jlog.logger;
+package com.jlog.logging;
 
 import java.io.IOException;
 

--- a/src/main/java/com/jlog/logging/MdcFilter.java
+++ b/src/main/java/com/jlog/logging/MdcFilter.java
@@ -1,4 +1,4 @@
-package com.jlog.logger;
+package com.jlog.logging;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -24,16 +24,10 @@ public class MdcFilter implements Filter {
         HttpServletRequest httpReq = (HttpServletRequest) request;
         String requestId = httpReq.getHeader("X-Request-ID");
         if (Objects.isNull(requestId) || requestId.isEmpty()) {
-            requestId = length8RandomUUID();
+            requestId = UUID.randomUUID().toString().substring(0, 8);
         }
         MDC.put("requestId", requestId);
         chain.doFilter(request, response);
         MDC.clear();
-    }
-
-    private String length8RandomUUID() {
-        return UUID.randomUUID()
-                .toString()
-                .substring(0, 8);
     }
 }

--- a/src/main/java/com/jlog/logging/MethodLogAspect.java
+++ b/src/main/java/com/jlog/logging/MethodLogAspect.java
@@ -1,21 +1,20 @@
-package com.jlog.logger;
+package com.jlog.logging;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.Signature;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Aspect
 @Component
+@Slf4j
 public class MethodLogAspect {
 
-    private static final Logger log = LoggerFactory.getLogger(MethodLogAspect.class);
-
     @Around("execution(* com.jlog..*(..)) && " +
-            "!within(com.jlog.logger.*) && " +
+            "!within(com.jlog.logging.*) && " +
             "!within(com.jlog.exception.*)")
     public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
         if (!log.isInfoEnabled()) {

--- a/src/test/java/com/jlog/domain/log/LogControllerTest.java
+++ b/src/test/java/com/jlog/domain/log/LogControllerTest.java
@@ -31,6 +31,7 @@ import com.jlog.domain.member.Member;
 import com.jlog.domain.member.Members;
 import com.jlog.domain.room.Room;
 
+@SuppressWarnings("removal")
 @WebMvcTest(LogController.class)
 class LogControllerTest {
 

--- a/src/test/java/com/jlog/domain/log/LogRequestTest.java
+++ b/src/test/java/com/jlog/domain/log/LogRequestTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import com.jlog.ValidationTest;
 
+@SuppressWarnings("removal")
 class LogRequestTest extends ValidationTest {
 
     private static final Long id = 1L;

--- a/src/test/java/com/jlog/domain/log/LogServiceTest.java
+++ b/src/test/java/com/jlog/domain/log/LogServiceTest.java
@@ -18,6 +18,7 @@ import com.jlog.domain.room.Room;
 import com.jlog.domain.room.RoomRepository;
 import com.jlog.exception.JLogException;
 
+@SuppressWarnings("removal")
 class LogServiceTest {
 
     private LogService sut;

--- a/src/test/java/com/jlog/domain/room/RoomControllerTest.java
+++ b/src/test/java/com/jlog/domain/room/RoomControllerTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jlog.domain.member.Member;
 import com.jlog.domain.member.Members;
 
+@SuppressWarnings("removal")
 @WebMvcTest(RoomController.class)
 class RoomControllerTest {
 

--- a/src/test/java/com/jlog/domain/room/RoomCreateRequestTest.java
+++ b/src/test/java/com/jlog/domain/room/RoomCreateRequestTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 import com.jlog.ValidationTest;
 
+@SuppressWarnings("removal")
 class RoomCreateRequestTest extends ValidationTest {
 
     private RoomCreateRequest sut;

--- a/src/test/java/com/jlog/domain/room/RoomJoinRequestTest.java
+++ b/src/test/java/com/jlog/domain/room/RoomJoinRequestTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import com.jlog.ValidationTest;
 
+@SuppressWarnings("removal")
 class RoomJoinRequestTest extends ValidationTest {
 
     private static final String roomCode = "roomCode";

--- a/src/test/java/com/jlog/domain/room/RoomServiceTest.java
+++ b/src/test/java/com/jlog/domain/room/RoomServiceTest.java
@@ -16,6 +16,7 @@ import com.jlog.domain.member.MemberRepository;
 import com.jlog.domain.member.Members;
 import com.jlog.exception.JLogException;
 
+@SuppressWarnings("removal")
 class RoomServiceTest {
 
     private RoomService sut;


### PR DESCRIPTION
- `JLogExceptionHandler`: RuntimeException 발생 시 로그에 출력되도록 수정
- `JLogException`: 사용하지 않는 생성자와 메서드 제거
- `SerializationConfig`: TimeZone을 KST(+09:00)로 명시
- `@Entity` 클래스 `Log`, `Member`, `Room`: javadoc에 따라 `@EqualsAndHashCode`의 `of = "id"` 속성을 id 필드에 대해 `@EqualsAndHashCode.Include` 애너테이션을 마킹하는 방식으로 변경
- 그 외: 구버전 API와 DTO에 `@Deprecated` 표시